### PR TITLE
Simplified use of BMessageRunner

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -787,15 +787,9 @@ MainWindow::_UpdateStatusMessage(BString message)
 	if (fStatusBar) {
 		fMessageBar->SetText(message.String());
 
-		// Cancel previous timer if any
-		if (fStatusClearRunner) {
-			delete fStatusClearRunner;
-			fStatusClearRunner = nullptr;
-		}
-
 		// Set up 5-second timer to clear message
-		BMessage* clearMsg = new BMessage(M_CLEAR_STATUS);
-		fStatusClearRunner = new BMessageRunner(BMessenger(this), clearMsg, 5000000, 1);
+		BMessage clearMsg(M_CLEAR_STATUS);
+		BMessageRunner::StartSending(this, &clearMsg, 5000000, 1);
 	}
 }
 

--- a/UndoableTextView.cpp
+++ b/UndoableTextView.cpp
@@ -17,8 +17,7 @@ UndoableTextView::UndoableTextView(const char* name)
 	:
 	BTextView(name, B_WILL_DRAW | B_SCROLL_VIEW_AWARE),
 	fCoalescing(false),
-	fRecording(true),
-	fTimer(nullptr)
+	fRecording(true)
 {
 	rgb_color viewColor = ui_color(B_DOCUMENT_BACKGROUND_COLOR);
 	rgb_color textColor = ui_color(B_DOCUMENT_TEXT_COLOR);
@@ -32,7 +31,6 @@ UndoableTextView::UndoableTextView(const char* name)
 
 UndoableTextView::~UndoableTextView()
 {
-	delete fTimer;
 }
 
 
@@ -152,17 +150,13 @@ UndoableTextView::StartCoalesceTimer()
 	fCoalescing = true;
 
 	BMessage timeoutMsg(M_COALESCE_TIMEOUT);
-	fTimer = new BMessageRunner(BMessenger(this), &timeoutMsg, kCoalesceDelay, 1);
+	BMessageRunner::StartSending(this, &timeoutMsg, kCoalesceDelay, 1);
 }
 
 
 void
 UndoableTextView::StopCoalesceTimer()
 {
-	if (fTimer) {
-		delete fTimer;
-		fTimer = nullptr;
-	}
 	fCoalescing = false;
 }
 

--- a/UndoableTextView.h
+++ b/UndoableTextView.h
@@ -50,8 +50,6 @@ private:
 
 	bool fCoalescing;
 	bool fRecording;
-
-	BMessageRunner* fTimer;
 };
 
 


### PR DESCRIPTION
By using a detached BMessageRunner's StartSending for the CoalesceTimer and status updater, we can avoid explicitely creating, deleting etc. BMessageRunners.

Just a little side product of a bughunt. Turned out it wasn't message related... :)