### PR TITLE
Fix crash when working with selections

### DIFF
--- a/TextUtils.cpp
+++ b/TextUtils.cpp
@@ -68,7 +68,7 @@ GetText(BTextView* textView, bool isLineBased)
 	}
 
 	char* buffer = new char[selEnd - selStart + 1];
-	textView->GetText(selStart, selEnd, buffer);
+	textView->GetText(selStart, selEnd - selStart, buffer);
 	buffer[selEnd - selStart] = '\0';
 
 	BString result(buffer);


### PR DESCRIPTION
The end of the text was incorrectly computed.

Running the app with "LD_PRELOAD=libroot_debug.so TextWorker" had Debugger point me in the right direction, saying "Someone wrote beyond small allocation at..." when crashing at `delete[] buffer` in TextUtils.cpp GetText().