### PR TITLE
Fix saving files

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -876,7 +876,7 @@ MainWindow::SaveFile(const char* path)
 	if (file.SetTo(path, B_READ_WRITE | B_CREATE_FILE | B_ERASE_FILE) != B_OK)
 		return;
 
-	if (BTranslationUtils::PutStyledText(fTextView, &file) == B_OK) {
+	if (BTranslationUtils::WriteStyledEditFile(fTextView, &file) == B_OK) {
 		fFilePath = path;
 
 		BPath p(path);


### PR DESCRIPTION
As the HaikuBook says:
	"You can use PutStyledText() to write styled text data
	to files, but it writes the data in a format that isn't
	human readable."

WriteStyledEditFile() works.

Fixes #16